### PR TITLE
fix: the missing $aws_args for removing old backups

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -90,11 +90,11 @@ if [ -n "$BACKUP_KEEP_DAYS" ]; then
   backups_query="Contents[?LastModified<='${date_from_remove} 00:00:00'].{Key: Key}"
 
   echo "Removing old backup from $S3_BUCKET..."
-  aws s3api list-objects \
+  aws $aws_args s3api list-objects \
     --bucket "${S3_BUCKET}" \
     --prefix "${S3_PREFIX}" \
     --query "${backups_query}" \
     --output text \
-    | xargs -n1 -t -I 'KEY' aws s3 rm s3://"${S3_BUCKET}"/'KEY'
+    | xargs -n1 -t -I 'KEY' aws $aws_args s3 rm s3://"${S3_BUCKET}"/'KEY'
   echo "Removing complete."
 fi


### PR DESCRIPTION
I want to use it for `s3-compatible` object storage, but only `aws s3 cp` is for custom `endpoint_url`, and the `$aws_args` is missing for `removing old backups`.