### PR TITLE
Discord notification after backup finishes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV S3_S3V4 'no'
 ENV SCHEDULE ''
 ENV PASSPHRASE ''
 ENV BACKUP_KEEP_DAYS ''
+ENV DISCORD_WEBHOOK_URL ''
 
 ADD src/run.sh run.sh
 ADD src/env.sh env.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ services:
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc
 - Use `BACKUP_KEEP_DAYS` to set time for how long you want to keep backup.
+- Use `DISCORD_WEBHOOK_URL` to send a notification on discord channel after a succesfully backup.
 
 ## Restore
 > **WARNING:** DATA LOSS! All database objects will be dropped and re-created.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,3 +26,4 @@ services:
       POSTGRES_DATABASE: postgres
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
+      DISCORD_WEBHOOK_URL: https://discord.com/api/webhooks/1234567890/abcdefghijklmnopqrstuvwxyz

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -36,9 +36,9 @@ echo "Backup complete."
 
 if [ -n "$DISCORD_WEBHOOK_URL" ]; then
   echo "Sending notification to Discord..."
-  curl -X POST -H "Content-Type: application/json" \
-    -d "{\"content\": \"Backup of $POSTGRES_DATABASE database completed: $s3_uri \"}" \
-    "$DISCORD_WEBHOOK_URL"
+
+  python3 -c "import requests; requests.post('$DISCORD_WEBHOOK_URL', json={'content': '[**backup**] of $POSTGRES_DATABASE database completed on $timestamp. URL: $s3_uri'})"
+
   echo "Notification sent."
 fi
 

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -34,6 +34,14 @@ rm "$local_file"
 
 echo "Backup complete."
 
+if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+  echo "Sending notification to Discord..."
+  curl -X POST -H "Content-Type: application/json" \
+    -d "{\"content\": \"Backup of $POSTGRES_DATABASE database completed: $s3_uri \"}" \
+    "$DISCORD_WEBHOOK_URL"
+  echo "Notification sent."
+fi
+
 if [ -n "$BACKUP_KEEP_DAYS" ]; then
   sec=$((86400*BACKUP_KEEP_DAYS))
   date_from_remove=$(date -d "@$(($(date +%s) - sec))" +%Y-%m-%d)


### PR DESCRIPTION
First of all, thanks for this project. I use it on all my services for a long time.

I'm sending this PR that sends a discord notification through webhooks, if you set ```DISCORD_WEBHOOK_URL```.

It helps me a lot and I hope it can help others. If is not the goal of this project (to add this kind of features) just ignore it.