### PR TITLE
Add support for PostgreSQL 16

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -16,6 +16,7 @@ jobs:
           - { postgres: 13, alpine: '3.14' }
           - { postgres: 14, alpine: '3.16' }
           - { postgres: 15, alpine: '3.17' }
+          - { postgres: 16, alpine: '3.19' }
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { postgres: 11, alpine: '3.10' }
           - { postgres: 12, alpine: '3.12' }
           - { postgres: 13, alpine: '3.14' }
           - { postgres: 14, alpine: '3.16' }

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This project provides Docker images to periodically back up a PostgreSQL databas
 ```yaml
 services:
   postgres:
-    image: postgres:13
+    image: postgres:16
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
 
   backup:
-    image: eeshugerman/postgres-backup-s3:15
+    image: eeshugerman/postgres-backup-s3:16
     environment:
       SCHEDULE: '@weekly'     # optional
       BACKUP_KEEP_DAYS: 7     # optional
@@ -28,7 +28,7 @@ services:
       POSTGRES_PASSWORD: password
 ```
 
-- Images are tagged by the major PostgreSQL version supported: `11`, `12`, `13`, `14`, or `15`.
+- Images are tagged by the major PostgreSQL version supported: `11`, `12`, `13`, `14`, `15` or `16`.
 - The `SCHEDULE` variable determines backup frequency. See go-cron schedules documentation [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules). Omit to run the backup immediately and then exit.
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ services:
       POSTGRES_PASSWORD: password
 ```
 
-- Images are tagged by the major PostgreSQL version supported: `11`, `12`, `13`, `14`, `15` or `16`.
+- Images are tagged by the major PostgreSQL version supported: `12`, `13`, `14`, `15` or `16`.
 - The `SCHEDULE` variable determines backup frequency. See go-cron schedules documentation [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules). Omit to run the backup immediately and then exit.
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc.

--- a/src/install.sh
+++ b/src/install.sh
@@ -11,9 +11,7 @@ apk add postgresql-client
 # install gpg
 apk add gnupg
 
-apk add python3
-apk add py3-pip  # separate package on edge only
-pip3 install awscli
+apk add aws-cli
 
 # install go-cron
 apk add curl


### PR DESCRIPTION
PostgreSQL 16 was released on 2023-09-14:
https://www.postgresql.org/about/news/postgresql-16-released-2715/

PostgreSQL 11 has reached end-of-life by 2023-11-09:
https://www.postgresql.org/support/versioning/

This PR enhances the build matrix (adding v16, removing v11), simplifies installing `aws-cli` (by using `apk`) and updates the README.