### PR TITLE
Adding S3_ENDPOINT in the environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ services:
       SCHEDULE: '@weekly'     # optional
       BACKUP_KEEP_DAYS: 7     # optional
       PASSPHRASE: passphrase  # optional
+      S3_ENDPOINT: https://my-endpoint # optional, for non-AWS S3-compatible storage provider
       S3_REGION: region
       S3_ACCESS_KEY_ID: key
       S3_SECRET_ACCESS_KEY: secret
@@ -33,7 +34,6 @@ services:
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc.
 - If `BACKUP_KEEP_DAYS` is set, backups older than this many days will be deleted from S3.
-- Set `S3_ENDPOINT` if you're using a non-AWS S3-compatible storage provider.
 
 ## Restore
 > **WARNING:** DATA LOSS! All database objects will be dropped and re-created.


### PR DESCRIPTION
Lots of people don't use AWS S3 as storage provider and I think it should be more explicit that we can use one with this docker image.

Feel free to update the PR if needed.

And thanks a lot for your work! 👍 