### PR TITLE
Match the POSTGRES_DB with default pg docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 ADD src/install.sh install.sh
 RUN sh install.sh && rm install.sh
 
-ENV POSTGRES_DATABASE ''
+ENV POSTGRES_DB ''
 ENV POSTGRES_HOST ''
 ENV POSTGRES_PORT 5432
 ENV POSTGRES_USER ''

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ services:
       S3_BUCKET: my-bucket
       S3_PREFIX: backup
       POSTGRES_HOST: postgres
-      POSTGRES_DATABASE: dbname
+      POSTGRES_DB: dbname
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,6 @@ services:
       S3_BUCKET:
       S3_PREFIX: backup
       POSTGRES_HOST: postgres
-      POSTGRES_DATABASE: postgres
+      POSTGRES_DB: postgres
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -5,17 +5,17 @@ set -o pipefail
 
 source ./env.sh
 
-echo "Creating backup of $POSTGRES_DATABASE database..."
+echo "Creating backup of $POSTGRES_DB database..."
 pg_dump --format=custom \
         -h $POSTGRES_HOST \
         -p $POSTGRES_PORT \
         -U $POSTGRES_USER \
-        -d $POSTGRES_DATABASE \
+        -d $POSTGRES_DB \
         $PGDUMP_EXTRA_OPTS \
         > db.dump
 
 timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
-s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${POSTGRES_DATABASE}_${timestamp}.dump"
+s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${POSTGRES_DB}_${timestamp}.dump"
 
 if [ -n "$PASSPHRASE" ]; then
   echo "Encrypting backup..."

--- a/src/env.sh
+++ b/src/env.sh
@@ -3,8 +3,8 @@ if [ -z "$S3_BUCKET" ]; then
   exit 1
 fi
 
-if [ -z "$POSTGRES_DATABASE" ]; then
-  echo "You need to set the POSTGRES_DATABASE environment variable."
+if [ -z "$POSTGRES_DB" ]; then
+  echo "You need to set the POSTGRES_DB environment variable."
   exit 1
 fi
 

--- a/src/restore.sh
+++ b/src/restore.sh
@@ -15,11 +15,11 @@ fi
 
 if [ $# -eq 1 ]; then
   timestamp="$1"
-  key_suffix="${POSTGRES_DATABASE}_${timestamp}${file_type}"
+  key_suffix="${POSTGRES_DB}_${timestamp}${file_type}"
 else
   echo "Finding latest backup..."
   key_suffix=$(
-    aws $aws_args s3 ls "${s3_uri_base}/${POSTGRES_DATABASE}" \
+    aws $aws_args s3 ls "${s3_uri_base}/${POSTGRES_DB}" \
       | sort \
       | tail -n 1 \
       | awk '{ print $4 }'
@@ -35,7 +35,7 @@ if [ -n "$PASSPHRASE" ]; then
   rm db.dump.gpg
 fi
 
-conn_opts="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DATABASE"
+conn_opts="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB"
 
 echo "Restoring from backup..."
 pg_restore $conn_opts --clean --if-exists db.dump


### PR DESCRIPTION
The official https://hub.docker.com/_/postgres image uses `POSTGRES_DB` as environment variable for the database name. I think this repo should match the name so we can use only one environment variable in our projects  