### PR TITLE
Support multiple databases through POSTGRES_DATABASE

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -5,47 +5,54 @@ set -o pipefail
 
 source ./env.sh
 
-echo "Creating backup of $POSTGRES_DATABASE database..."
-pg_dump --format=custom \
-        -h $POSTGRES_HOST \
-        -p $POSTGRES_PORT \
-        -U $POSTGRES_USER \
-        -d $POSTGRES_DATABASE \
-        $PGDUMP_EXTRA_OPTS \
-        > db.dump
+OIFS="$IFS"
+IFS=','
+for DB in $POSTGRES_DATABASE
+do
+  IFS="$OIFS"
+  
+	echo "Creating backup of $DB database..."
+	pg_dump --format=custom \
+			-h $POSTGRES_HOST \
+			-p $POSTGRES_PORT \
+			-U $POSTGRES_USER \
+			-d $DB \
+			$PGDUMP_EXTRA_OPTS \
+			> db.dump
 
-timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
-s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${POSTGRES_DATABASE}_${timestamp}.dump"
+	timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
+	s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${DB}_${timestamp}.dump"
 
-if [ -n "$PASSPHRASE" ]; then
-  echo "Encrypting backup..."
-  rm -f db.dump.gpg
-  gpg --symmetric --batch --passphrase "$PASSPHRASE" db.dump
-  rm db.dump
-  local_file="db.dump.gpg"
-  s3_uri="${s3_uri_base}.gpg"
-else
-  local_file="db.dump"
-  s3_uri="$s3_uri_base"
-fi
+	if [ -n "$PASSPHRASE" ]; then
+		echo "Encrypting backup..."
+		rm -f db.dump.gpg
+		gpg --symmetric --batch --passphrase "$PASSPHRASE" db.dump
+		rm db.dump
+		local_file="db.dump.gpg"
+		s3_uri="${s3_uri_base}.gpg"
+	else
+		local_file="db.dump"
+		s3_uri="$s3_uri_base"
+	fi
 
-echo "Uploading backup to $S3_BUCKET..."
-aws $aws_args s3 cp "$local_file" "$s3_uri"
-rm "$local_file"
+	echo "Uploading backup to $S3_BUCKET..."
+	aws $aws_args s3 cp "$local_file" "$s3_uri"
+	rm "$local_file"
 
-echo "Backup complete."
+	echo "Backup complete."
 
-if [ -n "$BACKUP_KEEP_DAYS" ]; then
-  sec=$((86400*BACKUP_KEEP_DAYS))
-  date_from_remove=$(date -d "@$(($(date +%s) - sec))" +%Y-%m-%d)
-  backups_query="Contents[?LastModified<='${date_from_remove} 00:00:00'].{Key: Key}"
+	if [ -n "$BACKUP_KEEP_DAYS" ]; then
+		sec=$((86400*BACKUP_KEEP_DAYS))
+		date_from_remove=$(date -d "@$(($(date +%s) - sec))" +%Y-%m-%d)
+		backups_query="Contents[?LastModified<='${date_from_remove} 00:00:00'].{Key: Key}"
 
-  echo "Removing old backups from $S3_BUCKET..."
-  aws $aws_args s3api list-objects \
-    --bucket "${S3_BUCKET}" \
-    --prefix "${S3_PREFIX}" \
-    --query "${backups_query}" \
-    --output text \
-    | xargs -n1 -t -I 'KEY' aws $aws_args s3 rm s3://"${S3_BUCKET}"/'KEY'
-  echo "Removal complete."
-fi
+		echo "Removing old backups from $S3_BUCKET..."
+		aws $aws_args s3api list-objects \
+			--bucket "${S3_BUCKET}" \
+			--prefix "${S3_PREFIX}" \
+			--query "${backups_query}" \
+			--output text \
+			| xargs -n1 -t -I 'KEY' aws $aws_args s3 rm s3://"${S3_BUCKET}"/'KEY'
+		echo "Removal complete."
+	fi
+done

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -11,48 +11,48 @@ for DB in $POSTGRES_DATABASE
 do
   IFS="$OIFS"
   
-	echo "Creating backup of $DB database..."
-	pg_dump --format=custom \
-			-h $POSTGRES_HOST \
-			-p $POSTGRES_PORT \
-			-U $POSTGRES_USER \
-			-d $DB \
-			$PGDUMP_EXTRA_OPTS \
-			> db.dump
+  echo "Creating backup of $DB database..."
+  pg_dump --format=custom \
+      -h $POSTGRES_HOST \
+      -p $POSTGRES_PORT \
+      -U $POSTGRES_USER \
+      -d $DB \
+      $PGDUMP_EXTRA_OPTS \
+      > db.dump
 
-	timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
-	s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${DB}_${timestamp}.dump"
+  timestamp=$(date +"%Y-%m-%dT%H:%M:%S")
+  s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}/${DB}_${timestamp}.dump"
 
-	if [ -n "$PASSPHRASE" ]; then
-		echo "Encrypting backup..."
-		rm -f db.dump.gpg
-		gpg --symmetric --batch --passphrase "$PASSPHRASE" db.dump
-		rm db.dump
-		local_file="db.dump.gpg"
-		s3_uri="${s3_uri_base}.gpg"
-	else
-		local_file="db.dump"
-		s3_uri="$s3_uri_base"
-	fi
+  if [ -n "$PASSPHRASE" ]; then
+    echo "Encrypting backup..."
+    rm -f db.dump.gpg
+    gpg --symmetric --batch --passphrase "$PASSPHRASE" db.dump
+    rm db.dump
+    local_file="db.dump.gpg"
+    s3_uri="${s3_uri_base}.gpg"
+  else
+    local_file="db.dump"
+    s3_uri="$s3_uri_base"
+  fi
 
-	echo "Uploading backup to $S3_BUCKET..."
-	aws $aws_args s3 cp "$local_file" "$s3_uri"
-	rm "$local_file"
+  echo "Uploading backup to $S3_BUCKET..."
+  aws $aws_args s3 cp "$local_file" "$s3_uri"
+  rm "$local_file"
 
-	echo "Backup complete."
+  echo "Backup complete."
 
-	if [ -n "$BACKUP_KEEP_DAYS" ]; then
-		sec=$((86400*BACKUP_KEEP_DAYS))
-		date_from_remove=$(date -d "@$(($(date +%s) - sec))" +%Y-%m-%d)
-		backups_query="Contents[?LastModified<='${date_from_remove} 00:00:00'].{Key: Key}"
+  if [ -n "$BACKUP_KEEP_DAYS" ]; then
+    sec=$((86400*BACKUP_KEEP_DAYS))
+    date_from_remove=$(date -d "@$(($(date +%s) - sec))" +%Y-%m-%d)
+    backups_query="Contents[?LastModified<='${date_from_remove} 00:00:00'].{Key: Key}"
 
-		echo "Removing old backups from $S3_BUCKET..."
-		aws $aws_args s3api list-objects \
-			--bucket "${S3_BUCKET}" \
-			--prefix "${S3_PREFIX}" \
-			--query "${backups_query}" \
-			--output text \
-			| xargs -n1 -t -I 'KEY' aws $aws_args s3 rm s3://"${S3_BUCKET}"/'KEY'
-		echo "Removal complete."
-	fi
+    echo "Removing old backups from $S3_BUCKET..."
+    aws $aws_args s3api list-objects \
+      --bucket "${S3_BUCKET}" \
+      --prefix "${S3_PREFIX}" \
+      --query "${backups_query}" \
+      --output text \
+      | xargs -n1 -t -I 'KEY' aws $aws_args s3 rm s3://"${S3_BUCKET}"/'KEY'
+    echo "Removal complete."
+  fi
 done


### PR DESCRIPTION
Added support for multiple databases. I found schicklings approach pretty straightforward. 

`POSTGRES_DATABASE=database1,database2,database3`.

Nothing has changed in how the database is backed up - simply allowing iterating over multiple. It could most likely be optimized - however, this is way better than having multiple docker containers running for different databases.

Simply copied the iterator from https://github.com/schickling/dockerfiles/blob/master/postgres-backup-s3/backup.sh

