### PR TITLE
Fix bug with S3_ENDPOINT not working due to aws_args being lost

### DIFF
--- a/src/env.sh
+++ b/src/env.sh
@@ -30,9 +30,9 @@ if [ -z "$POSTGRES_PASSWORD" ]; then
 fi
 
 if [ -z "$S3_ENDPOINT" ]; then
-  aws_args=""
+  export $aws_args=""
 else
-  aws_args="--endpoint-url $S3_ENDPOINT"
+  export $aws_args="--endpoint-url $S3_ENDPOINT"
 fi
 
 


### PR DESCRIPTION
Since this code was moved to a common `env.sh` file, the `aws_args` variable was lost. As a result, `S3_ENDPOINT` has no effect and upload fails. Simple fix is to export `aws_args`