### PR TITLE
Add restore confirmation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV S3_S3V4 'no'
 ENV SCHEDULE ''
 ENV PASSPHRASE ''
 ENV BACKUP_KEEP_DAYS ''
+ENV CONFIRM_RESTORE 'no'
 
 ADD src/run.sh run.sh
 ADD src/env.sh env.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ services:
       SCHEDULE: '@weekly'     # optional
       BACKUP_KEEP_DAYS: 7     # optional
       PASSPHRASE: passphrase  # optional
+      CONFIRM_RESTORE: 'no'   # optional
       S3_REGION: region
       S3_ACCESS_KEY_ID: key
       S3_SECRET_ACCESS_KEY: secret
@@ -34,6 +35,7 @@ services:
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc.
 - If `BACKUP_KEEP_DAYS` is set, backups older than this many days will be deleted from S3.
 - Set `S3_ENDPOINT` if you're using a non-AWS S3-compatible storage provider.
+- If `CONFIRM_RESTORE` is set to `'yes'`, a confirmation prompt will be displayed before restoring from a backup.
 
 ## Restore
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ services:
 
 ### ... from latest backup
 ```sh
-docker exec <container name> sh restore.sh
+docker exec -i <container name> sh restore.sh
 ```
 
 > [!NOTE]
@@ -51,7 +51,7 @@ docker exec <container name> sh restore.sh
 
 ### ... from specific backup
 ```sh
-docker exec <container name> sh restore.sh <timestamp>
+docker exec -i <container name> sh restore.sh <timestamp>
 ```
 
 # Development

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       SCHEDULE: '@weekly'     # optional
       BACKUP_KEEP_DAYS: 7     # optional
       PASSPHRASE: passphrase  # optional
+      CONFIRM_RESTORE: 'no'   # optional
       S3_REGION:
       S3_ACCESS_KEY_ID:
       S3_SECRET_ACCESS_KEY:

--- a/src/restore.sh
+++ b/src/restore.sh
@@ -6,7 +6,7 @@ set -o pipefail
 source ./env.sh
 
 if [ "$CONFIRM_RESTORE" = "yes" ]; then
-  echo "Are you sure you want to restore the database? This will overwrite the current database. (yes/no)"
+  echo "DATA LOSS! Are you sure you want to restore the database? This will overwrite the current database. (yes/no)"
   read confirm
   if [ "$confirm" != "yes" ]; then
     echo "Restore cancelled."

--- a/src/restore.sh
+++ b/src/restore.sh
@@ -5,6 +5,15 @@ set -o pipefail
 
 source ./env.sh
 
+if [ "$CONFIRM_RESTORE" = "yes" ]; then
+  echo "Are you sure you want to restore the database? This will overwrite the current database. (yes/no)"
+  read confirm
+  if [ "$confirm" != "yes" ]; then
+    echo "Restore cancelled."
+    exit 1
+  fi
+fi
+
 s3_uri_base="s3://${S3_BUCKET}/${S3_PREFIX}"
 
 if [ -z "$PASSPHRASE" ]; then


### PR DESCRIPTION
Hi 👋 

First of all, thanks for this Docker Image! I've found it very useful.  

This PR would add a confirmation prompt before restoring from a backup.   
I feel like since the restore happens with a `--clean` flag, it can be quite dangerous to run it accidentally.    
If I run the restore instead of the backup by mistake, I would lose all the data since the last backup.    
To prevent this, this PR would add a confirmation prompt before the restore.   