### PR TITLE
Add support for PostgreSQL 17

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -16,6 +16,7 @@ jobs:
           - { postgres: 14, alpine: '3.16' }
           - { postgres: 15, alpine: '3.17' }
           - { postgres: 16, alpine: '3.19' }
+          - { postgres: 17, alpine: '3.20' }
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -16,7 +16,7 @@ jobs:
           - { postgres: 14, alpine: '3.16' }
           - { postgres: 15, alpine: '3.17' }
           - { postgres: 16, alpine: '3.19' }
-          - { postgres: 17, alpine: '3.20' }
+          - { postgres: 17, alpine: '3.21' }
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This project provides Docker images to periodically back up a PostgreSQL databas
 ```yaml
 services:
   postgres:
-    image: postgres:16
+    image: postgres:17
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
 
   backup:
-    image: eeshugerman/postgres-backup-s3:16
+    image: eeshugerman/postgres-backup-s3:17
     environment:
       SCHEDULE: '@weekly'     # optional
       BACKUP_KEEP_DAYS: 7     # optional
@@ -28,7 +28,7 @@ services:
       POSTGRES_PASSWORD: password
 ```
 
-- Images are tagged by the major PostgreSQL version supported: `12`, `13`, `14`, `15` or `16`.
+- Images are tagged by the major PostgreSQL version supported: `12`, `13`, `14`, `15`, `16` or `17`.
 - The `SCHEDULE` variable determines backup frequency. See go-cron schedules documentation [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules). Omit to run the backup immediately and then exit.
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> sh backup.sh` to trigger a backup ad-hoc.


### PR DESCRIPTION
https://www.postgresql.org/about/news/postgresql-17-released-2936/


Currently, `postgresql-client` for v17 is not available in Alpine, so this PR needs to wait:
https://pkgs.alpinelinux.org/packages?name=postgresql17*&branch=edge&repo=main&arch=&maintainer=